### PR TITLE
Removing X-Real-IP as this appears to obfuscate downstream client IPs

### DIFF
--- a/proxyexamples/haproxy/haproxy.cfg
+++ b/proxyexamples/haproxy/haproxy.cfg
@@ -13,7 +13,6 @@ frontend normal
 	 mode http
 	 option forwardfor
 	 reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-	 option forwardfor header X-Real-IP
 	 reqirep ^([^\ :]*)\ /v2(.*$) \1\ /artifactory/api/docker/docker-virtual/v2\2
 	 default_backend normal
 
@@ -22,7 +21,6 @@ frontend dockerhub
 	 mode http
 	 option forwardfor
 	 reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-	 option forwardfor header X-Real-IP
 	 reqirep ^([^\ :]*)\ /v2(.*$) \1\ /artifactory/api/docker/docker-remote/v2\2
 	 default_backend normal
 
@@ -31,7 +29,6 @@ frontend dockerprod
 	 mode http
 	 option forwardfor
 	 reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-	 option forwardfor header X-Real-IP
 	 reqirep ^([^\ :]*)\ /v1(.*$) \1\ /artifactory/api/docker/docker-prod-local/v1\2
 	 reqirep ^([^\ :]*)\ /v2(.*$) \1\ /artifactory/api/docker/docker-prod-local2/v2\2
 	 default_backend normal
@@ -41,7 +38,6 @@ frontend dockerdev
 	 mode http
 	 option forwardfor
 	 reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-	 option forwardfor header X-Real-IP
 	 reqirep ^([^\ :]*)\ /v1(.*$) \1\ /artifactory/api/docker/docker-dev-local/v1\2
 	 reqirep ^([^\ :]*)\ /v2(.*$) \1\ /artifactory/api/docker/docker-dev-local2/v2\2
 	 default_backend normal


### PR DESCRIPTION
As stated in the commit comment, I was unable to see the client IPs hitting artifactory while using this configuration. Removing the 'option forwardfor X-Real-IP' forces the header to be the default header rather than 'X-Real-IP'. This allowed me to see client IPs in the artifactory logs.
