### PR TITLE
Update replicationDiff.sh

### DIFF
--- a/replicationDiff/replicationDiff.sh
+++ b/replicationDiff/replicationDiff.sh
@@ -172,7 +172,7 @@ fi
 curl -X GET -u$SOURCEUSER:$SOURCEPASSWORD "$SOURCEART/api/storage/$SOURCEREPO/?list&deep=1&listFolders=0&mdTimestamps=1&statsTimestamps=1&includeRootPath=1" -L > source.log
 curl -X GET -u$TARGETUSER:$TARGETPASSWORD "$TARGETART/api/storage/$TARGETREPO/?list&deep=1&listFolders=0&mdTimestamps=1&statsTimestamps=1&includeRootPath=1" -L > target.log
 
-diff source.log target.log > diff_output.txt
+diff --new-line-format="" --unchanged-line-format=""  source.log target.log > diff_output.txt
 sed -n '/uri/p' diff_output.txt | sed 's/[<>,]//g' | sed '/https/d' | sed '/http/d' | sed  's/ //g' | sed 's/[",]//g' | sed 's/uri://g' > cleanpaths.txt
 prefix=$SOURCEART/$SOURCEREPO
 awk -v prefix="$prefix" '{print prefix $0}' cleanpaths.txt > filepaths_uri.txt
@@ -307,7 +307,7 @@ fi
 
 curl -X GET -u$source_username:$source_password "$SOURCE_ART/api/storage/$Source_repo_name/?list&deep=1&listFolders=0&mdTimestamps=1&statsTimestamps=1&includeRootPath=1" -L > source.log
 curl -X GET -u$target_username:$target_password "$TARGET_ART/api/storage/$Target_repo_name/?list&deep=1&listFolders=0&mdTimestamps=1&statsTimestamps=1&includeRootPath=1" -L > target.log
-diff source.log target.log > diff_output.txt
+diff --new-line-format="" --unchanged-line-format=""  source.log target.log > diff_output.txt
 sed -n '/uri/p' diff_output.txt | sed 's/[<>,]//g' | sed '/https/d' | sed '/http/d' | sed  's/ //g' | sed 's/[",]//g' | sed 's/uri://g' > cleanpaths.txt
 prefix=$SOURCE_ART/$Source_repo_name
 awk -v prefix="$prefix" '{print prefix $0}' cleanpaths.txt > filepaths_uri.txt


### PR DESCRIPTION
Changed the way the diff was being done between the source repository and target repository. The new change will explicitly only report artifacts that are missing in the target repository and present in the source repository in Artifactory.

Previously there was an issue when reporting missing artifacts.