### PR TITLE
remove duplicate request

### DIFF
--- a/filestoreIntegrity/filestoreIntegrity.py
+++ b/filestoreIntegrity/filestoreIntegrity.py
@@ -62,7 +62,6 @@ def runRequest(conn, path, skipmsg=False):
     req.add_header('Authorization', auth)
     try:
         with urllib.request.urlopen(req) as resp:
-            resp = urllib.request.urlopen(req)
             stat = resp.getcode()
             if skipmsg and stat in (200, 404): msg = None
             else: msg = resp.read()


### PR DESCRIPTION
With the removed line in place, every request is duplicate, for example:
20200413162059|2|REQUEST|0:0:0:0:0:0:0:1|admin|GET|/api/repositories|HTTP/1.1|200|0
20200413162059|1|REQUEST|0:0:0:0:0:0:0:1|admin|GET|/api/repositories|HTTP/1.1|200|0
or
20200413160551|2|REQUEST|0:0:0:0:0:0:0:1|admin|GET|/php-local/recentVuls.txt|HTTP/1.1|200|14941
20200413162751|3|REQUEST|0:0:0:0:0:0:0:1|admin|GET|/php-local/recentVuls.txt|HTTP/1.1|200|14941

Removing this line produced the same output, but with a single request for each artifact/repo