### PR TITLE
fix issue with white spaces in artifacts names

### DIFF
--- a/filestoreIntegrity/filestoreIntegrity.py
+++ b/filestoreIntegrity/filestoreIntegrity.py
@@ -51,6 +51,7 @@ def getArtifactList(conn, repo):
 # request an artifact, and return a summary of the artifact if the response code
 # wasn't 200 or 404
 def checkArtifact(conn, repo, artif):
+    artif = urllib.parse.quote(artif)
     stat, msg = runRequest(conn, '/{}{}'.format(repo, artif), skipmsg=True)
     if stat in (200, 404): return None
     return '[{} {}] {}{}'.format(stat, msg, repo, artif)


### PR DESCRIPTION
Added a parsing for the artifact's name in order to avoid this error when the artficat name has a white space:
http.client.InvalidURL: URL can't contain control characters. '/artifactory/generic-local/file with space.jar' (found at least ' ')