### PR TITLE
Update haproxy-ha.cfg

### DIFF
--- a/proxyexamples/haproxy/haproxy-ha.cfg
+++ b/proxyexamples/haproxy/haproxy-ha.cfg
@@ -1,34 +1,35 @@
-# Features enabled by this configuration
-# port 80  Artifactory GUI/API
-# Load Balancing for HA
-# Sticky Sessions
-
+# HAPRoxy Configuration for Artifactory 7 HA 
 global
-    log 127.0.0.1   local0
-    log 127.0.0.1   local1 notice
-    maxconn 256000
-    user haproxy
-    group haproxy
-    daemon
-    #debug
-    #quiet
- 
+    log 127.0.0.1 local0 debug
+    maxconn 256000
+    user haproxy
+    group haproxy
+    daemon
+
 defaults
-    log global
-    mode    tcp
-    option  tcplog
-    option  dontlognull
-    retries 3
-    option redispatch
-    maxconn 256000
-    contimeout  5000
-    clitimeout  50000
-    srvtimeout  50000
- 
-listen artifactory_http 10.80.166.106:80
-    mode http
-    balance roundrobin
-    cookie SERVERID insert indirect nocache
-    server  server1 10.10.10.1:8081  check cookie server1
-    server  server2 10.10.10.2:8081  check cookie server2
-    server  server3 10.10.10.3:8081  check cookie server3
+    log global
+    mode http
+    maxconn 256000
+    option  forwardfor except 127.0.0.1
+    timeout  http-request 10s
+    timeout  queue 1m
+    timeout  connect 5s
+    timeout  client 1m
+    timeout  server 1m
+
+frontend front_in
+    bind *:80
+    mode http
+    option forwardfor
+    capture request header Host len 32
+    default_backend artifactory
+
+backend artifactory
+    mode http
+    balance roundrobin
+    option forwardfor
+    option http-server-close
+    cookie SERVERID insert indirect nocache
+    default-server fastinter 200ms downinter 200ms inter 3s fall 3 rise 2
+    server art01 parimay-node:8082 check
+    server art02 secondary-node:8082 check


### PR DESCRIPTION
The previous, 5 years old config is not supported by newer HAProxy versions. This config was tested with a two node 7.10.2 Artifactory HA cluster, and it successfully redirects requests to the online node, should the other one go offline.