### PR TITLE
Fixed: DownloadUsage.py invalid syntax, requirements.txt issues

### DIFF
--- a/DownloadUsage/DownloadUsage.py
+++ b/DownloadUsage/DownloadUsage.py
@@ -23,7 +23,7 @@ with open(readfile) as f:
     print("Parsing Access Log...")
     for line in f:
         try:
-            p = re.compile(ur'(\d*)-(\d*-\d*\d*......)(........)(.*])(.*)(:)(.*)(for)(.)(.*)(\/)(.*)(\.)')
+            p = re.compile(r'(\d*)-(\d*-\d*\d*......)(........)(.*])(.*)(:)(.*)(for)(.)(.*)(\/)(.*)(\.)')
             match = re.match(p,line)
             if "ACCEPTED DOWNLOAD" in match.group(4):
                 checkfile = match.group(5) + "/" + match.group(7)

--- a/DownloadUsage/DownloadUsage.py
+++ b/DownloadUsage/DownloadUsage.py
@@ -3,7 +3,6 @@ import re
 import requests
 import json
 from colorama import Fore, Back, Style
-import colorama
 
 username = "admin" #EDIT THIS
 password = "password" #EDIT THIS

--- a/DownloadUsage/DownloadUsage.py
+++ b/DownloadUsage/DownloadUsage.py
@@ -20,7 +20,7 @@ totalbytes = 0
 notfound = 0
 
 with open(readfile) as f:
-    print "Parsing Access Log..."
+    print("Parsing Access Log...")
     for line in f:
         try:
             p = re.compile(ur'(\d*)-(\d*-\d*\d*......)(........)(.*])(.*)(:)(.*)(for)(.)(.*)(\/)(.*)(\.)')
@@ -36,7 +36,7 @@ with open(readfile) as f:
         except Exception:
             notfound +=1 #An error may occur if the file has been deleted. This script is not perfect.
             pass
-print Fore.RED + "Could not find",(notfound),"artifacts(most likely deleted)" 
-print Fore.GREEN + "Total download usage:",(totalbytes/1000000),"MB"
-print (Style.RESET_ALL)
+print(Fore.RED + "Could not find",(notfound),"artifacts(most likely deleted)")
+print(Fore.GREEN + "Total download usage:",(totalbytes/1000000),"MB")
+print(Style.RESET_ALL)
 exit()

--- a/DownloadUsage/requirements.txt
+++ b/DownloadUsage/requirements.txt
@@ -1,5 +1,2 @@
-sys
-re
 requests
-json
 colorama


### PR DESCRIPTION
Adding fixes for the DownloadUsage.py script, as it failed to execute due to requirements.txt and invalid syntax errors:

* Fixed print statement declarations
* Removed duplicate import statement (colorama)
* Replaced 'ur' string type with the synonym 'r' on ln 25 (which is compatible with both Py2 and Py3).
* Removed dependencies from requirements.txt which are installed as part of Python and not found on Pip:

```
   ERROR: Could not find a version that satisfies the requirement sys
   ERROR: No matching distribution found for sys
   ERROR: Could not find a version that satisfies the requirement re
   ERROR: No matching distribution found for re
   ERROR: Could not find a version that satisfies the requirement json
   ERROR: No matching distribution found for json
```

Changes verified on Python 3.8.2.